### PR TITLE
Add OpenLineage reporting support for Spark connector

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -34,8 +34,9 @@ github:
     squash:  true
     merge:   false
     rebase:  true
+  autolink_jira: HBASE
 notifications:
   commits:      commits@hbase.apache.org
   issues:       issues@hbase.apache.org
   pullrequests: issues@hbase.apache.org
-  jira_options: link
+  jira_options: link label

--- a/pom.xml
+++ b/pom.xml
@@ -933,5 +933,18 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <!-- Use Mac x64 version of protoc for Apple Silicon (aarch64) Macs -->
+      <id>osx-aarch64</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <properties>
+        <os.detected.classifier>osx-x86_64</os.detected.classifier>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,7 @@
     <scoverage.version>1.4.11</scoverage.version>
     <sbt-compiler.version>1.0.0</sbt-compiler.version>
     <jacoco.version>0.8.8</jacoco.version>
+    <openlineage.version>1.20.5</openlineage.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -242,6 +243,17 @@
         <groupId>org.apache.yetus</groupId>
         <artifactId>audience-annotations</artifactId>
         <version>${audience-annotations.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.openlineage</groupId>
+        <artifactId>spark-extension-interfaces</artifactId>
+        <version>${openlineage.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.openlineage</groupId>
+        <artifactId>spark-extension-entrypoint</artifactId>
+        <version>1.0.0</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>
@@ -387,7 +399,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>3.4.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/spark/hbase-spark/pom.xml
+++ b/spark/hbase-spark/pom.xml
@@ -182,6 +182,21 @@
       <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.openlineage</groupId>
+      <artifactId>spark-extension-interfaces</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.openlineage</groupId>
+      <artifactId>spark-extension-entrypoint</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.openlineage</groupId>
+      <artifactId>openlineage-spark_2.12</artifactId>
+      <version>${openlineage.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -264,6 +279,26 @@
             </rule>
           </rules>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>io.openlineage.spark.shade</pattern>
+                  <shadedPattern>org.apache.hbase.thirdparty.io.openlineage.spark.shade</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/spark/hbase-spark/src/main/resources/META-INF/services/io.openlineage.spark.extension.OpenLineageExtensionProvider
+++ b/spark/hbase-spark/src/main/resources/META-INF/services/io.openlineage.spark.extension.OpenLineageExtensionProvider
@@ -1,0 +1,1 @@
+org.apache.hadoop.hbase.spark.SparkHBaseLineageProvider

--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/DefaultSource.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/DefaultSource.scala
@@ -137,7 +137,7 @@ case class HBaseRelation(
       .getInt(HBaseSparkConf.BULKGET_SIZE, HBaseSparkConf.DEFAULT_BULKGET_SIZE))
 
   // create or get latest HBaseContext
-  val hbaseContext: HBaseContext = if (useHBaseContext) {
+  val hbaseContext: HBaseContext = if (useHBaseContext && LatestHBaseContextCache.latest != null) {
     LatestHBaseContextCache.latest
   } else {
     val hadoopConfig = sqlContext.sparkContext.hadoopConfiguration

--- a/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/SparkHBaseLineageProvider.scala
+++ b/spark/hbase-spark/src/main/scala/org/apache/hadoop/hbase/spark/SparkHBaseLineageProvider.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.spark
+
+import io.openlineage.spark.extension.OpenLineageExtensionProvider
+import io.openlineage.spark.shade.extension.v1.lifecycle.plan.SparkOpenLineageExtensionVisitor
+
+class SparkHBaseLineageProvider extends OpenLineageExtensionProvider {
+
+  def shadedPackage(): String =
+    "org.apache.hbase.thirdparty.io.openlineage.spark.shade"
+
+  override def getVisitorClassName: String =
+    classOf[SparkOpenLineageExtensionVisitor].getCanonicalName
+}

--- a/spark/hbase-spark/src/test/scala/org/apache/hadoop/hbase/spark/DefaultSourceSuite.scala
+++ b/spark/hbase-spark/src/test/scala/org/apache/hadoop/hbase/spark/DefaultSourceSuite.scala
@@ -1359,4 +1359,16 @@ class DefaultSourceSuite
         }
     }
   }
+
+  test("NPE should not be thrown even when HBaseContext was never initialized") {
+    LatestHBaseContextCache.latest = null
+    val catalog = s"""{"table":{"namespace":"default", "name":"table"},
+                     | "rowkey":"key",
+                     | "columns":{"c1":{"cf":"d", "col":"c1", "type":"string"}}}""".stripMargin
+    try {
+      HBaseRelation(Map(HBaseTableCatalog.tableCatalog -> catalog), None)(sqlContext)
+    } catch {
+      case _: NullPointerException => fail("Unexpected NPE thrown")
+    }
+  }
 }

--- a/spark/hbase-spark/src/test/scala/org/apache/hadoop/hbase/spark/OpenLineageSuite.scala
+++ b/spark/hbase-spark/src/test/scala/org/apache/hadoop/hbase/spark/OpenLineageSuite.scala
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.spark
+
+import io.openlineage.spark.agent.OpenLineageSparkListener
+import java.io.File
+import org.apache.hadoop.hbase.{HBaseTestingUtility, TableName}
+import org.apache.hadoop.hbase.client.{ConnectionFactory, Put}
+import org.apache.hadoop.hbase.spark.datasources.{HBaseSparkConf, HBaseTableCatalog}
+import org.apache.hadoop.hbase.util.Bytes
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{SparkSession, SQLContext}
+import org.json4s._
+import org.json4s.jackson.JsonMethods._
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FunSuite}
+import org.scalatest.Matchers.convertToAnyShouldWrapper
+import org.scalatest.concurrent.Eventually
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
+class OpenLineageSuite
+    extends FunSuite
+    with Eventually
+    with BeforeAndAfterEach
+    with BeforeAndAfterAll
+    with Logging {
+  @transient var sc: SparkSession = null
+  var TEST_UTIL: HBaseTestingUtility = new HBaseTestingUtility
+
+  val t1TableName = "t1"
+  val t2TableName = "t2"
+  val columnFamily = "c"
+  var sqlContext: SQLContext = null
+
+  val timestamp = 1234567890000L
+  val lineageFile = File.createTempFile(s"openlineage_test_${System.nanoTime()}", ".log")
+
+  override def beforeAll() {
+
+    TEST_UTIL.startMiniCluster
+
+    logInfo(" - minicluster started")
+    try
+      TEST_UTIL.deleteTable(TableName.valueOf(t1TableName))
+    catch {
+      case e: Exception => logInfo(" - no table " + t1TableName + " found")
+    }
+    try
+      TEST_UTIL.deleteTable(TableName.valueOf(t2TableName))
+    catch {
+      case e: Exception => logInfo(" - no table " + t2TableName + " found")
+    }
+
+    logInfo(" - creating table " + t1TableName)
+    TEST_UTIL.createTable(TableName.valueOf(t1TableName), Bytes.toBytes(columnFamily))
+    logInfo(" - created table")
+    logInfo(" - creating table " + t2TableName)
+    TEST_UTIL.createTable(TableName.valueOf(t2TableName), Bytes.toBytes(columnFamily))
+    logInfo(" - created table")
+
+    val sparkConf = new SparkConf
+    sparkConf.set(HBaseSparkConf.QUERY_CACHEBLOCKS, "true")
+    sparkConf.set(HBaseSparkConf.QUERY_BATCHSIZE, "100")
+    sparkConf.set(HBaseSparkConf.QUERY_CACHEDROWS, "100")
+    sparkConf.set("spark.extraListeners", classOf[OpenLineageSparkListener].getCanonicalName)
+    sparkConf.set("spark.openlineage.transport.type", "file")
+    sparkConf.set("spark.openlineage.transport.location", lineageFile.getAbsolutePath)
+
+    sc = SparkSession
+      .builder()
+      .master("local")
+      .appName("openlineage-test")
+      .config(sparkConf)
+      .getOrCreate();
+    val connection = ConnectionFactory.createConnection(TEST_UTIL.getConfiguration)
+    try {
+      val t1Table = connection.getTable(TableName.valueOf(t1TableName))
+
+      try {
+        var put = new Put(Bytes.toBytes("get1"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("a"), Bytes.toBytes("foo1"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("b"), Bytes.toBytes("1"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("i"), Bytes.toBytes(1))
+        t1Table.put(put)
+        put = new Put(Bytes.toBytes("get2"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("a"), Bytes.toBytes("foo2"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("b"), Bytes.toBytes("4"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("i"), Bytes.toBytes(4))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("z"), Bytes.toBytes("FOO"))
+        t1Table.put(put)
+        put = new Put(Bytes.toBytes("get3"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("a"), Bytes.toBytes("foo3"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("b"), Bytes.toBytes("8"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("i"), Bytes.toBytes(8))
+        t1Table.put(put)
+        put = new Put(Bytes.toBytes("get4"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("a"), Bytes.toBytes("foo4"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("b"), Bytes.toBytes("10"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("i"), Bytes.toBytes(10))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("z"), Bytes.toBytes("BAR"))
+        t1Table.put(put)
+        put = new Put(Bytes.toBytes("get5"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("a"), Bytes.toBytes("foo5"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("b"), Bytes.toBytes("8"))
+        put.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("i"), Bytes.toBytes(8))
+        t1Table.put(put)
+      } finally {
+        t1Table.close()
+      }
+    } finally {
+      connection.close()
+    }
+
+    new HBaseContext(sc.sparkContext, TEST_UTIL.getConfiguration)
+  }
+
+  override def afterAll() {
+    TEST_UTIL.deleteTable(TableName.valueOf(t1TableName))
+    logInfo("shuting down minicluster")
+    TEST_UTIL.shutdownMiniCluster()
+
+    sc.stop()
+  }
+
+  override def beforeEach(): Unit = {
+    DefaultSourceStaticUtils.lastFiveExecutionRules.clear()
+  }
+
+  test("Test rowKey point only rowKey query") {
+    val hbaseTable1Catalog =
+      s"""{
+         |"table":{"namespace":"default", "name":"t1"},
+         |"rowkey":"key",
+         |"columns":{
+         |"KEY_FIELD":{"cf":"rowkey", "col":"key", "type":"string"},
+         |"A_FIELD":{"cf":"c", "col":"a", "type":"string"},
+         |"B_FIELD":{"cf":"c", "col":"b", "type":"string"}
+         |}
+         |}""".stripMargin
+
+    val hbaseTable2Catalog =
+      s"""{
+         |"table":{"namespace":"default", "name":"t2"},
+         |"rowkey":"key",
+         |"columns":{
+         |"KEY_FIELD":{"cf":"rowkey", "col":"key", "type":"string"},
+         |"OUTPUT_A_FIELD":{"cf":"c", "col":"a", "type":"string"},
+         |"OUTPUT_B_FIELD":{"cf":"c", "col":"b", "type":"string"}
+         |}
+         |}""".stripMargin
+
+    val results = sc.read
+      .options(Map(HBaseTableCatalog.tableCatalog -> hbaseTable1Catalog))
+      .format("org.apache.hadoop.hbase.spark")
+      .load()
+
+    results.createOrReplaceTempView("tempview");
+
+    val outputDf =
+      sc.sql("SELECT KEY_FIELD, A_FIELD AS OUTPUT_A_FIELD, B_FIELD AS OUTPUT_B_FIELD FROM tempview")
+
+    outputDf.write
+      .format("org.apache.hadoop.hbase.spark")
+      .options(Map(HBaseTableCatalog.tableCatalog -> hbaseTable2Catalog))
+      .save()
+
+    val events = eventually {
+      val eventLog = parseEventLog(lineageFile); eventLog.size shouldBe 1; eventLog
+    }
+
+    val json = events.head
+    assert(((json \\ "inputs")(0) \ "name") == JString("default.t1"))
+    assert(((json \\ "inputs")(0) \ "namespace") == JString("hbase://127.0.0.1"))
+    assert(((json \\ "outputs")(0) \ "name") == JString("default.t2"))
+    assert(((json \\ "outputs")(0) \ "namespace") == JString("hbase://127.0.0.1"))
+  }
+
+  def parseEventLog(file: File): List[JValue] = {
+    val source = Source.fromFile(file)
+    val eventlist = ArrayBuffer.empty[JValue]
+    for (line <- source.getLines()) {
+      val event = parse(line)
+      for {
+        JObject(child) <- event
+        JField("inputs", JArray(inputs)) <- child
+        JField("outputs", JArray(outputs)) <- child
+        JField("eventType", JString(eventType)) <- child
+        if outputs.nonEmpty && inputs.nonEmpty && eventType == "COMPLETE"
+      } yield eventlist += event
+    }
+    eventlist.toList
+  }
+}


### PR DESCRIPTION
This PR introduces OpenLineage support to the Spark HBase connector. The following changes and enhancements have been made:

* **Integration with OpenLineage**: Implemented the `LineageRelationProvider` and `LineageRelation` interfaces in the `DefaultSource` and `HBaseRelation` classes, respectively, to provide input and output dataset identifiers.

* Metadata Enrichment: Enhanced the connector to publish detailed lineage information, including datasets and operation facets.
* Compatibility: Ensured compatibility with existing Spark jobs using the connector, allowing seamless lineage tracking without requiring significant modifications.

### Key Benefits:
* Improved Visibility: Provides enhanced visibility into data flow and transformations within Spark jobs using the HBase connector.
* Facilitates Auditing and Compliance: Helps in tracking data lineage, aiding in auditing and compliance efforts.
* Eases Debugging and Monitoring: Simplifies debugging and monitoring of data pipelines by providing detailed lineage information.
Please review the changes and provide feedback. Your input is valuable in ensuring the robustness and utility of this integration.